### PR TITLE
Changes to make creating a Vivado project from base.tcl a little easier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ The _base overlay_ is a regular Overlay (bitstream + hwh) that is loaded at boot
 
 The `boot_leds` PYNQ package uses `base`, which is a simple LED dancing script. It is located at `/boot/boot.py` in the PYNQ rootfs.
 
+#### AC Notes
+cd into /Zybo-Z7-20/base/base
+
+Make sure you have sourced the vivado setup script.
+
+First generate the HLS IP:
+run `build_hls.sh`
+
+Then to open vivado and create base/base.xpr:
+run `create_project.sh`
+
 ### Installing overlays
 
 Overlays should contain at minimum the `.bit` and `.hwh` file of the block design project and to globally install them, copy them to `~/pynq/overlays` and update `__init__.py`.

--- a/Zybo-Z7-20/base/base/base.tcl
+++ b/Zybo-Z7-20/base/base/base.tcl
@@ -1901,4 +1901,9 @@ unassigned#qspi0_ss_b#qspi0_io[0]#qspi0_io[1]#qspi0_io[2]#qspi0_io[3]/HOLD_B#qsp
 
 create_root_design ""
 
+make_wrapper -files [get_files base/base.srcs/sources_1/bd/base/base.bd] -top
+
+add_files -norecurse base/base.gen/sources_1/bd/base/hdl/base_wrapper.v
+
+
 

--- a/Zybo-Z7-20/base/base/base.tcl
+++ b/Zybo-Z7-20/base/base/base.tcl
@@ -30,6 +30,7 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
    return 1
 }
 
+
 ################################################################
 # START
 ################################################################
@@ -39,14 +40,17 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 # If there is no project opened, this script will create a
 # project, but make sure you do not have an existing project
-# <./myproj/project_1.xpr> in the current working folder.
+# <./base/base.xpr> in the current working folder.
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg400-1
-   set_property BOARD_PART digilentinc.com:zybo-z7-20:part0:1.2 [current_project]
+   xhub::install [xhub::get_xitems digilentinc.com:xilinx_board_store:zybo-z7-20:1.1]
+   create_project base base -part xc7z020clg400-1
+   set_property BOARD_PART digilentinc.com:zybo-z7-20:part0:1.1 [current_project]
 }
 
+set_property  ip_repo_paths  ../../../ip [current_project]
+update_ip_catalog
 
 # CHANGE DESIGN NAME HERE
 variable design_name

--- a/Zybo-Z7-20/base/base/build_hls.sh
+++ b/Zybo-Z7-20/base/base/build_hls.sh
@@ -1,0 +1,2 @@
+vivado -mode batch -source build_ip.tcl -notrace
+

--- a/Zybo-Z7-20/base/base/build_ip.tcl
+++ b/Zybo-Z7-20/base/base/build_ip.tcl
@@ -1,0 +1,69 @@
+# Copyright (C) 2022 Xilinx, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Rebuild HLS IP from source
+set current_dir [pwd]
+cd ../../../ip/hls/
+# get list of IP from folder names
+set ip {color_convert pixel_pack pixel_unpack trace_cntrl_32 trace_cntrl_64}
+# Check and build each IP
+foreach item $ip {
+   if {[catch { glob -directory ${item}/solution1/impl/ip/ *.zip} zip_file]} {
+# Build IP only if a packaged IP does not exist
+      puts "Building $item IP"
+      exec vitis_hls -f $item/script.tcl
+   } else {
+# Skip IP when a packaged IP exists in ip directory
+      puts "Skipping building $item"
+   }
+   unset zip_file
+# Testing the built IP
+   puts "Checking $item"
+   set fd [open ${item}/solution1/syn/report/${item}_csynth.rpt r]
+   set timing_flag 0
+   set latency_flag 0
+   while { [gets $fd line] >= 0 } {
+# Check whether the timing has been met
+    if [string match {+ Timing: } $line]  { 
+      set timing_flag 1
+      set latency_flag 0
+      continue
+    }
+    if {$timing_flag == 1} {
+      if [regexp {[0-9]+} $line]  {
+        set period [regexp -all -inline {[0-9]*\.[0-9]*} $line]
+        lassign $period target estimated uncertainty
+        if {$target < $estimated} {
+            puts "ERROR: Estimated clock period $estimated > target $target."
+            puts "ERROR: Revise $item to be compatible with vitis_hls."
+            exit 1
+        }
+      }
+    }
+# Check whether the II has been met
+    if [string match {+ Latency: } $line]  { 
+      set timing_flag 0
+      set latency_flag 1
+      continue
+    }
+    if {$latency_flag == 1} {
+      if [regexp {[0-9]+} $line]  {
+        set interval [regexp -all -inline {[0-9]*\.*[0-9]*} $line]
+        lassign $interval lc_min lc_max la_min la_max achieved target
+        if {$achieved != $target} {
+            puts "ERROR: Achieved II $achieved != target $target."
+            puts "ERROR: Revise $item to be compatible with vitis_hls."
+            exit 1
+        }
+      }
+    }
+# Testing ends
+    if [string match {== Utilization Estimates} $line]  { 
+       unset timing_flag latency_flag period interval
+       break
+    }
+   }
+   unset fd
+}
+cd $current_dir
+puts "HLS IP builds complete"

--- a/Zybo-Z7-20/base/base/create_project.sh
+++ b/Zybo-Z7-20/base/base/create_project.sh
@@ -1,0 +1,2 @@
+vivado -source base.tcl
+


### PR DESCRIPTION
Hi Gabriel,

Just a few changes to make creating a Vivado project a little easier from base.tcl

I have added a couple of scripts:

`build_hls.sh` makes sure that the HLS IP is built
`create_project.sh` opens Vivado and creates the project from the tcl.

Also I made the following changes to the TCL:

You had board part `digilentinc.com:zybo-z7-20:part0:1.2`, I'm not sure where you got this from, the one in their repository is 1.1. So I changes this to 1.1 and also added a line to install it if it was not available.

I added in ip_repro_paths and updated the ip catalog so that the ip could be found.

I also changed the name of the project to base, maybe you had a reason for myproj?

I added a couple of lines at the bottom to create and add the wrapper.

I put some notes in the ReadMe, I'm guessing you would want to move these.

Cheers

Andy

